### PR TITLE
Update CorsMiddleware.php

### DIFF
--- a/src/CorsMiddleware.php
+++ b/src/CorsMiddleware.php
@@ -18,9 +18,12 @@ class CorsMiddleware
     {
         $allow = $this->getPermission();
 
-        return $next($request)->header('Access-Control-Allow-Origin', $allow)
-            ->header('Access-Control-Allow-Methods', 'POST, GET, OPTIONS, PUT, DELETE, PATCH')
-            ->header('Access-Control-Allow-Headers', 'Content-Type, Accept, Authorization, X-Requested-With, Origin');
+        $response = $next($request);
+        $response->headers->set('Access-Control-Allow-Origin' , $allow);
+        $response->headers->set('Access-Control-Allow-Methods', 'POST, GET, OPTIONS, PUT, DELETE, PATCH');
+        $response->headers->set('Access-Control-Allow-Headers', 'Content-Type, Accept, Authorization, X-Requested-With, Origin');
+
+        return $response;
     }
 
     public function getPermission()


### PR DESCRIPTION
Mudado a forma de retorno para ser possível retornar arquivo em rotas pois no retorno estava ligando ->header() para um Response objeto que não possui essa função (Symfony\Component\HttpFoundation\BinaryFileResponseclasse).
A ->header() função é parte de uma característica que é usada pela classe de resposta do Laravel , e não a base da Symfony Response. Felizmente, você tem acesso à headers propriedade, para que possa fazer isso. 
Feito todos os teste e todas rotas funcionando.